### PR TITLE
fix(style/function): change textarea to input

### DIFF
--- a/src/chat/Chat.styles.tsx
+++ b/src/chat/Chat.styles.tsx
@@ -93,7 +93,7 @@ export const Input = styled.input`
   }
 `;
 
-export const InputMessage = styled.textarea`
+export const InputMessage = styled.input`
   width: 80%;
   height: 100px;
   background: transparent;


### PR DESCRIPTION
Pessoal, 

Devido ao layout não se adaptar as quebras de linha do textarea na hora de mostrar no chat, penso que seria mais agradável mudar para um input, e consequentemente, o submit nativo pela tecla enter irá funcionar normalmente, dando assim uma segunda opção para o usuário que poderá enviar a sua mensagem tanto clicando no botão quanto usando a tecla enter do teclado.